### PR TITLE
Handle no enrichment cases

### DIFF
--- a/gprofiler/__init__.py
+++ b/gprofiler/__init__.py
@@ -143,6 +143,8 @@ def gprofiler(query, organism='hsapiens', ordered_query=False, significant=True,
     split_query = map(lambda s: s.split('\t'), split_query)
 
     enrichment = pd.DataFrame(list(split_query))
+    if enrichment.empty: return None # handle no enrichment cases
+
     enrichment.columns = ["query.number", "significant", "p.value", "term.size",
                           "query.size", "overlap.size", "recall", "precision",
                           "term.id", "domain", "subgraph.number", "term.name",

--- a/tests/test_gprofiler.py
+++ b/tests/test_gprofiler.py
@@ -3,3 +3,6 @@ from gprofiler import gprofiler
 def test_enrichment_call():
     enrichment = gprofiler(['Klf4', 'Pax5', 'Sox2', 'Nanog'], organism='mmusculus')
     assert enrichment is not None
+
+    enrichment = gprofiler(['NOGENE'])
+    assert enrichment is None


### PR DESCRIPTION
Right now "no enrichment" cases raises the following exception:

`ValueError: Length mismatch: Expected axis has 0 elements, new values have 14 elements`

Better return just None.